### PR TITLE
Set the interval for querying highstate job status to 120s

### DIFF
--- a/templates/pnda.yaml
+++ b/templates/pnda.yaml
@@ -230,7 +230,7 @@ resources:
         #!/bin/bash -v
         set -e
         set -o pipefail
-        salt -v --log-level=debug --state-output=mixed '*' state.highstate | tee salt-highstate-$(date +"%F-%T").log
+        salt -v --log-level=debug --timeout=120 --state-output=mixed '*' state.highstate | tee salt-highstate-$(date +"%F-%T").log
   deploy_highstate:
         type: OS::Heat::SoftwareDeployment
         depends_on: [deploy_install,pnda_cluster]
@@ -284,7 +284,7 @@ resources:
             #!/bin/bash -v
             set -e
             set -o pipefail
-            salt -v --log-level=debug --state-output=mixed '*' state.highstate | tee salt-highstate-$(date +"%F-%T").log
+            salt -v --log-level=debug --timeout=120 --state-output=mixed '*' state.highstate | tee salt-highstate-$(date +"%F-%T").log
             CLUSTER=cname salt-run --log-level=debug state.orchestrate orchestrate.pnda-expand | tee salt-expand-$(date +"%F-%T").log
           params:
             cname: { get_param: 'OS::stack_name' }


### PR DESCRIPTION
Highstate is seen to finish running after the next phase, orchestrate
has already started, causing a race condition. It is thought that
increasing the poll interval lessens the probability of this happening.
PNDA-1984
