### PR TITLE
Updates to volume sizes

### DIFF
--- a/templates/pico/dn.yaml.j2
+++ b/templates/pico/dn.yaml.j2
@@ -50,7 +50,7 @@ parameters:
     default: default
   logvolume_size:
     type: number
-    default: 250
+    default: 10
   log_mountpoint:
     type: string
     default: /dev/vdb

--- a/templates/pico/edge.yaml.j2
+++ b/templates/pico/edge.yaml.j2
@@ -42,7 +42,7 @@ parameters:
     default: standard
   logvolume_size:
     type: number
-    default: 250
+    default: 10
   log_mountpoint:
     type: string
     default: /dev/vdb

--- a/templates/pico/instance_flavors.yaml
+++ b/templates/pico/instance_flavors.yaml
@@ -5,6 +5,7 @@ parameter_defaults:
   EdgeFlavor: pico-edge
   KafkaFlavor: pico-kafka
   DatanodeFlavor: pico-dn
-  BastionFlavor: pnda-micro
+  BastionFlavor: pico-bastion
+  SaltmasterFlavor: pico-saltmaster
   DatanodeVolumeSize: 35
   PndaFlavor: pico

--- a/templates/pico/kafka.yaml.j2
+++ b/templates/pico/kafka.yaml.j2
@@ -44,7 +44,7 @@ parameters:
     default: standard
   logvolume_size:
     type: number
-    default: 250
+    default: 10
   log_mountpoint:
     type: string
     default: /dev/vdb

--- a/templates/pico/mgr1.yaml.j2
+++ b/templates/pico/mgr1.yaml.j2
@@ -39,7 +39,7 @@ parameters:
     default: standard
   logvolume_size:
     type: number
-    default: 250
+    default: 10
   log_mountpoint:
     type: string
     default: /dev/vdb


### PR DESCRIPTION
pico log volumes now default to 10GB and the bastion and saltmaster use
dedicated pico instance flavors with smaller disks.

PNDA-2386