### PR TITLE
Log volume consistency changes

### DIFF
--- a/templates/standard/cm.yaml
+++ b/templates/standard/cm.yaml
@@ -33,7 +33,7 @@ parameters:
     default: standard
   logvolume_size:
     type: number
-    default: 500
+    default: 250
   signal_transport:
     type: string
   software_config_transport:

--- a/templates/standard/dn.yaml
+++ b/templates/standard/dn.yaml
@@ -31,7 +31,7 @@ parameters:
     type: string
   volume_size:
     type: number
-    default: 200
+    default: 50
   cluster_name:
     type: string
   pnda_secgroup:
@@ -41,7 +41,7 @@ parameters:
     default: default
   logvolume_size:
     type: number
-    default: 250
+    default: 120
   signal_transport:
     type: string
   software_config_transport:

--- a/templates/standard/edge.yaml
+++ b/templates/standard/edge.yaml
@@ -36,7 +36,7 @@ parameters:
     default: standard
   logvolume_size:
     type: number
-    default: 250
+    default: 120
   prvolume_size:
     type: number
     default: 10

--- a/templates/standard/kafka.yaml
+++ b/templates/standard/kafka.yaml
@@ -38,7 +38,7 @@ parameters:
     default: standard
   logvolume_size:
     type: number
-    default: 250
+    default: 120
   signal_transport:
     type: string
   software_config_transport:

--- a/templates/standard/logserver.yaml
+++ b/templates/standard/logserver.yaml
@@ -33,7 +33,7 @@ parameters:
     default: standard
   logvolume_size:
     type: number
-    default: 500
+    default: 250
   signal_transport:
     type: string
   software_config_transport:

--- a/templates/standard/mgr1.yaml
+++ b/templates/standard/mgr1.yaml
@@ -33,7 +33,7 @@ parameters:
     default: standard
   logvolume_size:
     type: number
-    default: 250
+    default: 120
   signal_transport:
     type: string
   software_config_transport:

--- a/templates/standard/mgr2.yaml
+++ b/templates/standard/mgr2.yaml
@@ -33,7 +33,7 @@ parameters:
     default: standard
   logvolume_size:
     type: number
-    default: 250
+    default: 120
   signal_transport:
     type: string
   software_config_transport:

--- a/templates/standard/mgr3.yaml
+++ b/templates/standard/mgr3.yaml
@@ -33,7 +33,7 @@ parameters:
     default: standard
   logvolume_size:
     type: number
-    default: 250
+    default: 120
   signal_transport:
     type: string
   software_config_transport:

--- a/templates/standard/mgr4.yaml
+++ b/templates/standard/mgr4.yaml
@@ -33,7 +33,7 @@ parameters:
     default: standard
   logvolume_size:
     type: number
-    default: 250
+    default: 120
   signal_transport:
     type: string
   software_config_transport:


### PR DESCRIPTION
Reduce the log volume size from 250 to 120GB. Reduce
the logserver main volume from 500 to 250GB.

PNDA-2430