### PR TITLE
Reduce the number of Groups created to the bare minimum needed.

### DIFF
--- a/templates/standard/pnda_cluster.yaml.j2
+++ b/templates/standard/pnda_cluster.yaml.j2
@@ -139,63 +139,13 @@ parameters:
     default: POLL_TEMP_URL
 
 resources:
-  HbaseGwAAGroup:
-    type: OS::Nova::ServerGroup
-    properties:
-      name:
-        str_replace:
-          template:
-            cname-hbasegw-aagroup
-          params:
-            cname: { get_param: deployment_name }
-      policies: [anti-affinity]
-  HdfsNnAAGroup:
-    type: OS::Nova::ServerGroup
-    properties:
-      name:
-        str_replace:
-          template:
-            cname-hdfsnn-aagroup
-          params:
-            cname: { get_param: deployment_name }
-      policies: [anti-affinity]
-  HdfsJnAAGroup:
-    type: OS::Nova::ServerGroup
-    properties:
-      name:
-        str_replace:
-          template:
-            cname-hrfsjn-aagroup
-          params:
-            cname: { get_param: deployment_name }
-      policies: [anti-affinity]
-  HzkAAGroup:
+  MgrAAGroup:
     type: OS::Nova::ServerGroup
     properties:
       name:
         str_replace:
           template:
             cname-hzk-aagroup
-          params:
-            cname: { get_param: deployment_name }
-      policies: [anti-affinity]
-  MasterAAGroup:
-    type: OS::Nova::ServerGroup
-    properties:
-      name:
-        str_replace:
-          template:
-            cname-master-aagroup
-          params:
-            cname: { get_param: deployment_name }
-      policies: [anti-affinity]
-  YarnRmAAGroup:
-    type: OS::Nova::ServerGroup
-    properties:
-      name:
-        str_replace:
-          template:
-            cname-yarnrm-aagroup
           params:
             cname: { get_param: deployment_name }
       policies: [anti-affinity]
@@ -490,7 +440,7 @@ resources:
       pnda_secgroup: { get_param: PndaSecGroup }
       cluster_name: { get_param: deployment_name }
       pnda_flavor: { get_param: PndaFlavor }
-      scheduler_group_hint: { get_resource: HzkAAGroup}
+      scheduler_group_hint: { get_resource: MgrAAGroup}
   manager2:
     type: OS::Pnda::manager2
     properties:
@@ -510,7 +460,7 @@ resources:
       pnda_secgroup: { get_param: PndaSecGroup }
       cluster_name: { get_param: deployment_name }
       pnda_flavor: { get_param: PndaFlavor }
-      scheduler_group_hint: { get_resource: HzkAAGroup}
+      scheduler_group_hint: { get_resource: MgrAAGroup}
   manager3:
     type: OS::Pnda::manager3
     properties:
@@ -549,7 +499,7 @@ resources:
       pnda_secgroup: { get_param: PndaSecGroup }
       cluster_name: { get_param: deployment_name }
       pnda_flavor: { get_param: PndaFlavor }
-      scheduler_group_hint: { get_resource: HzkAAGroup}
+      scheduler_group_hint: { get_resource: MgrAAGroup}
   edge:
     type: OS::Pnda::edge
     properties:


### PR DESCRIPTION
All the services that are HA were under a single groups as openstack
doesn't allow to associate more than one group per instance.

So all HA services:
HbaseGw
HdfsNn
HdfsJn
Hzk
Master
YarnRm

Are distributed over MGR instances (1, 2 and 4) and a single AA group can be
used defined as:
MgrAAGroup