### PR TITLE
Allow hypervisor_count the be defined in the pnda_env file.

### DIFF
--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -157,3 +157,10 @@ parameter_defaults:
   # AWS_REGION: AWS region to use to access the s3 bucket that contains application packages
   # 
   #AWS_REGION=xxxx
+
+  #
+  # hypervisor_count: The number of available hypervisors the distribute the Anti-Affiliate servers over.
+  # This optional parameter can be used to enable Anti-Affiliate support.
+  #
+  #hypervisor_count: 30
+


### PR DESCRIPTION
Defining a hypervisor_count in the pnda_enf file which triggers the evaluation of Anti-Affiliate groups usage.

hypervisor_count defines the number of available hypervisors the distribute the Anti-Affiliate servers over.
This optional parameter can be used to trigger Anti-Affiliate support.
Commenting out this parameter will disable Anti-Affiliate support altogether. 