### PR TITLE
Move yum repo defs to a backup folder

### DIFF
--- a/scripts/package_install.sh
+++ b/scripts/package_install.sh
@@ -14,7 +14,8 @@ if [ "x$DISTRO" == "xubuntu" ]; then
   (curl -L 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add - ) && echo 'deb [arch=amd64] https://deb.nodesource.com/node_6.x trusty main' > /etc/apt/sources.list.d/nodesource.list
   apt-get update
 elif [ "x$DISTRO" == "xrhel" ]; then
-
+mkdir -p /etc/yum.repos.d.backup/
+mv /etc/yum.repos.d/* /etc/yum.repos.d.backup/
 yum-config-manager --add-repo $PNDA_MIRROR/mirror_rpm
 rpm --import $PNDA_MIRROR/mirror_rpm/RPM-GPG-KEY-redhat-release
 rpm --import $PNDA_MIRROR/mirror_rpm/RPM-GPG-KEY-mysql


### PR DESCRIPTION
To make sure that only the PNDA mirror is used during setup we now move
the repo defs to another folder.

PNDA-2987