### PR TITLE
PNDA-2389 - PNDA automatically reboots instances that need rebooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added:
 - PNDA-2969: Allow hadoop distro to be set in `pnda_env.yaml`. Supported values are `HDP` and `CDH`.
+- PNDA-2389: PNDA automatically reboots instances that need rebooting following kernel updates
 
 ### Changed
 - PNDA-2965: Rename `cloudera_*` role grains to `hadoop_*`

--- a/cli/heat_cli.py
+++ b/cli/heat_cli.py
@@ -291,6 +291,8 @@ def create_cluster(args):
                                                                                                          stack_params_string)
     print cmdline
     os_cmd(cmdline, print_output=True)
+    print 'Nodes may reboot due to kernel upgrade, wait for few minutes'
+    time.sleep(180)
     console_info = subprocess.check_output(['nova', 'list', '--name', "%s-hadoop-edge" % pnda_cluster, '--fields', 'networks'])
     console_ip = re.search('([0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*)', console_info)
     if console_ip:

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -97,6 +97,11 @@ parameter_defaults:
   platform_git_repo_uri: 'https://github.com/pndaproject/platform-salt.git'
 
   #
+  # Beacon timeout to check system reboot 
+  #
+  PLATFORM_SALT_BEACON_TIMEOUT: 30
+
+  #
   # PndaMirror: URI of the mirror for offline installation
   #  
   PndaMirror: 'http://www.example.com'

--- a/scripts/base_install.sh
+++ b/scripts/base_install.sh
@@ -37,6 +37,9 @@ log_level_logfile: debug
 
 backend: requests
 requests_lib: True
+beacons:
+  kernel_reboot_required:
+    interval: $PLATFORM_SALT_BEACON_TIMEOUT
 EOF
 
 # Set up the grains

--- a/scripts/saltmaster_install.sh
+++ b/scripts/saltmaster_install.sh
@@ -62,6 +62,8 @@ reactor:
     - salt://reactor/create_bastion_host_entry.sls
   - 'salt/cloud/*/destroying':
     - salt://reactor/delete_bastion_host_entry.sls
+  - 'salt/beacon/*/kernel_reboot_required/*/reboot-required':
+    - salt://reactor/kernel_reboot_entry.sls
 ## end of specific PNDA saltmaster config
 file_recv: True
 


### PR DESCRIPTION
User story:
      PNDA-2389 - PNDA automatically reboots instances that need rebooting following kernel updates

Analysis:
      During deployment sometimes needs reboot VM because of kernel  upgrade

Change:
1.	Reboot VMs if it’s required during deployment
2.	Update node reboot status in metrics page every 30 seconds 
Files changed
1.	Added beacon timeout entry in pnda-env.yaml file
2.	Added beacon entry in scripts/base_install.sh
3.	Added Reactor entry in scripts/saltmaster_install.sh
4.	Add 180 seconds sleep time after orchastration 
     
Test details:
1.	Check last reboot time using “last reboot” command
2.	Check metrics page verify the reboot value
