### PR TITLE
Platform salt Issue 290: Deployment failed due to saltstack 

### DIFF
--- a/templates/pnda.yaml
+++ b/templates/pnda.yaml
@@ -334,7 +334,7 @@ resources:
         #!/bin/bash -v
         set -e
         set -o pipefail
-        salt -v --log-level=debug --timeout=120 --state-output=mixed '*' state.highstate | tee salt-highstate-$(date +"%F-%T").log
+        salt -v --log-level=debug --timeout=120 --state-output=mixed '*' state.highstate queue=True | tee salt-highstate-$(date +"%F-%T").log
   deploy_highstate:
         type: OS::Heat::SoftwareDeployment
         depends_on: [deploy_install,pnda_cluster]
@@ -394,8 +394,8 @@ resources:
             #!/bin/bash -v
             set -e
             set -o pipefail
-            salt -v --log-level=debug --timeout=120 --state-output=mixed '*' state.sls hostsfile | tee salt-highstate-$(date +"%F-%T").log
-            salt -v --log-level=debug --timeout=120 --state-output=mixed -C "G@pnda:is_new_node" state.highstate | tee salt-highstate-$(date +"%F-%T").log
+            salt -v --log-level=debug --timeout=120 --state-output=mixed '*' state.sls hostsfile queue=True | tee salt-highstate-$(date +"%F-%T").log
+            salt -v --log-level=debug --timeout=120 --state-output=mixed -C "G@pnda:is_new_node" state.highstate queue=True| tee salt-highstate-$(date +"%F-%T").log
             CLUSTER=cname salt-run --log-level=debug state.orchestrate orchestrate.pnda-expand | tee salt-expand-$(date +"%F-%T").log
           params:
             cname: { get_param: 'OS::stack_name' }


### PR DESCRIPTION
Problem Statement:
By default SaltStack not queuing job, need to enable queue in all salt calls

Analysis:
Enable the beacon at any point of time one job would have been running i.e HIGH State or each of the Orchestrate states. After the beacon configuring, beacon run in the specified intervals (for milli seconds or so) . As per default salt state flow only one job can run at any point of time. Now if another job starts at the same time, salt will not allow it. Now if we want salt jobs in parallel we need to specify a parameter called queue = True. By default it is False.

Change:
The fix is needed to be in aws-template <pnda-cli.py> and heat template for HIGH state and in pnda-salt orchestrate all the jobs to be added with this parameter.

Test details:
Run deployment several times and ensure it will not break in the middle.