### PR TITLE
PNDA-2390 - PNDA restarts any services that need restarting when rebooted

### DIFF
--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -99,7 +99,7 @@ parameter_defaults:
   #
   # Beacon timeout to check system reboot 
   #
-  PLATFORM_SALT_BEACON_TIMEOUT: 30
+  platform_salt_beacon_timeout: 30
 
   #
   # PndaMirror: URI of the mirror for offline installation

--- a/scripts/base_install.sh
+++ b/scripts/base_install.sh
@@ -37,9 +37,13 @@ log_level_logfile: debug
 
 backend: requests
 requests_lib: True
+EOF
+
+cat >> /etc/salt/minion.d/beacons.conf <<EOF
 beacons:
   kernel_reboot_required:
-    interval: $PLATFORM_SALT_BEACON_TIMEOUT
+    interval: $beacon_timeout$
+  $beacons$
 EOF
 
 # Set up the grains

--- a/templates/pico/bastion.yaml.j2
+++ b/templates/pico/bastion.yaml.j2
@@ -12,6 +12,11 @@ parameters:
     description: Flavor of the bastion server
     type: string
     default: ec2.t2.medium
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -115,6 +120,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $roles$: 'bastion'
             $master_ip$: { get_param: SaltmasterIP }

--- a/templates/pico/dn.yaml.j2
+++ b/templates/pico/dn.yaml.j2
@@ -13,6 +13,11 @@ parameters:
     description: Flavor of the datanode server
     type: string
     default: ec2.c4.xlarge
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -86,6 +91,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }

--- a/templates/pico/edge.yaml.j2
+++ b/templates/pico/edge.yaml.j2
@@ -13,6 +13,11 @@ parameters:
     description: Flavor of the edge server
     type: string
     default: ec2.m3.xlarge
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -96,6 +101,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }
@@ -104,6 +110,10 @@ resources:
 {%endif%}
             $roles$: 'hadoop_edge,console_frontend,console_backend_data_logger,console_backend_data_manager,graphite,gobblin,deployment_manager,package_repository,data_service,impala-shell,yarn-gateway,hbase_opentsdb_tables,hdfs_cleaner,master_dataset,elk,logserver,kibana_dashboard,jupyter,hadoop_manager,platform_testing_cdh,mysql_connector,pnda_restart'
             $hadoop_role$: 'EDGE'
+            $beacons$: |
+                service_restart:
+                    interval: 30
+                    disable_during_state_run: True
             $$SPECIFIC_CONF$$: { get_param: specific_config }
   deploy_package:
     type: OS::Heat::SoftwareDeployment

--- a/templates/pico/kafka.yaml.j2
+++ b/templates/pico/kafka.yaml.j2
@@ -13,6 +13,11 @@ parameters:
     description: Flavor of the kafka server
     type: string
     default: ec2.m3.large
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -83,6 +88,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $brokerid$: { get_param: NodeIndex}

--- a/templates/pico/mgr1.yaml.j2
+++ b/templates/pico/mgr1.yaml.j2
@@ -13,6 +13,11 @@ parameters:
     description: Flavor of the manager1 server
     type: string
     default: ec2.m3.xlarge
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -92,6 +97,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }
             $flavor$: { get_param: pnda_flavor }

--- a/templates/pnda.yaml
+++ b/templates/pnda.yaml
@@ -132,6 +132,11 @@ parameters:
     default: ''
     description: |
       uri to the platform-salt upstream git repository
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   signal_transport:
     type: string
     default: TEMP_URL_SIGNAL
@@ -241,6 +246,7 @@ resources:
       NtpServers: { get_param: NtpServers }
       keystone_auth_url: { get_param: keystone_auth_url }
       platform_git_repo_uri: { get_param: platform_git_repo_uri }
+      platform_salt_beacon_timeout: { get_param: platform_salt_beacon_timeout }
       platform_uri: { get_param: platform_uri }
 
   package_config:
@@ -252,6 +258,7 @@ resources:
           template: { get_file: scripts/package_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $platform_salt_beacon_timeout$: { get_param: platform_salt_beacon_timeout }
 
   # A SoftwareConfig resource contains all the parameters used when provisioning PNDA
   install_config:

--- a/templates/standard/bastion.yaml
+++ b/templates/standard/bastion.yaml
@@ -8,6 +8,11 @@ parameters:
     description: Flavor of the bastion server
     type: string
     default: ec2.t2.medium
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -104,6 +109,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $roles$: 'bastion'
             $master_ip$: { get_param: SaltmasterIP }

--- a/templates/standard/cm.yaml
+++ b/templates/standard/cm.yaml
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the hadoop manager server
     type: string
     default: ec2.m3.xlarge
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -85,11 +90,16 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }
             $log_volume_id$: { get_resource: logvolume }
             $roles$: 'hadoop_manager,platform_testing_cdh,mysql_connector,pnda_restart'
+            $beacons$: |
+                service_restart:
+                    interval: 30
+                    disable_during_state_run: True
             $hadoop_role$: 'CM'
             $$SPECIFIC_CONF$$: { get_param: specific_config }
   deploy_package:

--- a/templates/standard/dn.yaml.j2
+++ b/templates/standard/dn.yaml.j2
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the datanode server
     type: string
     default: ec2.m4.2xlarge
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -80,6 +85,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }

--- a/templates/standard/edge.yaml.j2
+++ b/templates/standard/edge.yaml.j2
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the edge server
     type: string
     default: ec2.t2.medium
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -96,6 +101,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }

--- a/templates/standard/jupyter.yaml
+++ b/templates/standard/jupyter.yaml
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the jupyter server
     type: string
     default: ec2.m3.large
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -78,6 +83,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }

--- a/templates/standard/kafka.yaml.j2
+++ b/templates/standard/kafka.yaml.j2
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the kafka server
     type: string
     default: ec2.m3.xlarge
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -77,6 +82,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $brokerid$: { get_param: NodeIndex}

--- a/templates/standard/logserver.yaml
+++ b/templates/standard/logserver.yaml
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the logserver server
     type: string
     default: ec2.m3.large
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -85,6 +90,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }

--- a/templates/standard/mgr1.yaml
+++ b/templates/standard/mgr1.yaml
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the manager1 server
     type: string
     default: ec2.m3.2xlarge
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -83,6 +88,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }
             $flavor$: { get_param: pnda_flavor }

--- a/templates/standard/mgr2.yaml
+++ b/templates/standard/mgr2.yaml
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the manager2 server
     type: string
     default: ec2.m3.2xlarge
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -83,6 +88,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }

--- a/templates/standard/mgr3.yaml
+++ b/templates/standard/mgr3.yaml
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the manager3 server
     type: string
     default: ec2.m3.2xlarge
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -82,6 +87,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }

--- a/templates/standard/mgr4.yaml
+++ b/templates/standard/mgr4.yaml
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the manager4 server
     type: string
     default: ec2.m3.2xlarge
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -84,6 +89,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }

--- a/templates/standard/opentsdb.yaml
+++ b/templates/standard/opentsdb.yaml
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the opentsdb server
     type: string
     default: ec2.m3.xlarge
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -73,6 +78,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }

--- a/templates/standard/tools.yaml
+++ b/templates/standard/tools.yaml
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the tools server
     type: string
     default: ec2.m3.large
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -70,6 +75,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }

--- a/templates/standard/zookeeper.yaml.j2
+++ b/templates/standard/zookeeper.yaml.j2
@@ -9,6 +9,11 @@ parameters:
     description: Flavor of the zookeeper server
     type: string
     default: ec2.m3.large
+  platform_salt_beacon_timeout:
+    type: string
+    default: '30'
+    description: |
+      default beacon timeout for saltstack
   KeyName:
     description: Name of an existing ssh keypair
     type: string
@@ -77,6 +82,7 @@ resources:
           template: {get_file: scripts/base_install.sh }
           params:
             $pnda_mirror$: { get_param: PndaMirror }
+            $beacon_timeout$: { get_param: platform_salt_beacon_timeout }
             $flavor$: { get_param: pnda_flavor }
             $master_ip$: { get_param: SaltmasterIP }
             $pnda_cluster$: { get_param: cluster_name }


### PR DESCRIPTION
User story:
PNDA-2390 - PNDA restarts any services that need restarting when rebooted

Analysis:
if any CDH/HDP services are down, need to restart, beacon running in CM node, if any Hadoop service is down it will restart.

Change:

add beacon entry in cm manager node, change in cm node Yaml in a template.

Test details:

Check the /etc/salt/minion.d/beacons.conf have proper entry.
