### PR TITLE
Issue 121: SALTSTACK-GPG-KEY.pub fails through http from http://repo.saltstack.com 

### DIFF
--- a/scripts/package_install.sh
+++ b/scripts/package_install.sh
@@ -10,7 +10,7 @@ if [ "x$DISTRO" == "xubuntu" ]; then
   sed -i "1ideb $PNDA_MIRROR/mirror_deb/ ./" /etc/apt/sources.list
   wget -O - $PNDA_MIRROR/mirror_deb/pnda.gpg.key | apt-key add -
   (curl -L 'https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/archive.key' | apt-key add - ) && echo 'deb [arch=amd64] https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/ trusty-cm5.9.0 contrib' > /etc/apt/sources.list.d/cloudera-manager.list
-  (curl -L 'http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add - ) && echo 'deb [arch=amd64] http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main' > /etc/apt/sources.list.d/saltstack.list
+  (curl -L 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add - ) && echo 'deb [arch=amd64] https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main' > /etc/apt/sources.list.d/saltstack.list
   (curl -L 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add - ) && echo 'deb [arch=amd64] https://deb.nodesource.com/node_6.x trusty main' > /etc/apt/sources.list.d/nodesource.list
   apt-get update
 elif [ "x$DISTRO" == "xrhel" ]; then


### PR DESCRIPTION

Problem Statement:
============
Issue 121: SALTSTACK-GPG-KEY.pub fails through http from http://repo.saltstack.com 

Analysis:
=====
If the IT infrastructure in an organization not allowed http traffic, then getting the key from  "http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub" will be failed,
because of that the deployment will not be successful.

Solution:
=====
Fix : Change http to https 


Files Changed :
=========
scripts/package_install.sh
curl -L 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add - ) && echo 'deb [arch=amd64] https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main' > /etc/apt/sources.list.d/saltstack.list

Tests:
===
1. Deploy PNDA for PICO flavor with Ubuntu
2. Deploy PNDA for PICO flavor with RHEL