### PR TITLE
fixes #123, added the jenkins gpg key for RHEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+- Issue-123: Fixed Jenkins GPG Key Added in pacage-install.sh file
 ## [Unreleased]
 ### Added:
 - PNDA-2969: Allow hadoop distro to be set in `pnda_env.yaml`. Supported values are `HDP` and `CDH`.

--- a/scripts/package_install.sh
+++ b/scripts/package_install.sh
@@ -23,5 +23,6 @@ rpm --import $PNDA_MIRROR/mirror_rpm/RPM-GPG-KEY-cloudera
 rpm --import $PNDA_MIRROR/mirror_rpm/RPM-GPG-KEY-EPEL-7
 rpm --import $PNDA_MIRROR/mirror_rpm/SALTSTACK-GPG-KEY.pub
 rpm --import $PNDA_MIRROR/mirror_rpm/RPM-GPG-KEY-CentOS-7
+rpm --import $PNDA_MIRROR/mirror_rpm/RPM-GPG-KEY-Jenkins
 
 fi


### PR DESCRIPTION
Fixes #123  added missingJenkins  gpg key for Jenkins for RHEL

Changes in : scripts/package_install.sh
+rpm --import $PNDA_MIRROR/mirror_rpm/RPM-GPG-KEY-Jenkins
