### PR TITLE
PNDA-3299 Support multiple NTP servers properly

### DIFF
--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -110,9 +110,11 @@ parameter_defaults:
   #
   # NtpServers: Optional ntp servers. Use this if the standard Ubuntu NTP servers on the Internet cannot be reached
   # and a local NTP server has been configured. PNDA will not work without NTP.
-  # example format: 'xxx.ntp.org'
-  NtpServers: ''
-
+  # example formats as below 
+  # NtpServers: "['ntp.ubuntu.com', '91.189.94.4', '0.ubuntu.pool.ntp.org']" 
+  # NtpServers: "['ntp.ubuntu.com']" 
+  # NtpServers: '' 
+  NtpServers: "['ntp.ubuntu.com']" 
   # APPLICATION PACKAGE REPOSITORY
   
   #

--- a/scripts/iprejecter.sh
+++ b/scripts/iprejecter.sh
@@ -13,7 +13,8 @@ for key in "${!specific[@]}"; do conf[$key]="${specific[${key}]}"; done
 # built the white list ip address
 ## mirror ntp and dns servers are white listed
 MIRRORSERVER=$(echo '$pnda_mirror$' | awk -F/ '{print $3}' | awk -F: '{print $1}')
-NTPSERVER=$(echo '$ntp_servers$' | awk '{print $1}')
+
+NTPSERVER=$(echo "$ntp_servers" | sed -e 's|[]"'\''\[ ]||g')
 KEYSTONE=$(echo '$keystone_auth_url$' | awk -F/ '{print $3}' | awk -F: '{print $1}')
 DNSLIST=$(cat /etc/resolv.conf  | grep -E -o  "([0-9]{1,3}[\.]){3}[0-9]{1,3}")
 

--- a/scripts/saltmaster_install.sh
+++ b/scripts/saltmaster_install.sh
@@ -150,7 +150,7 @@ if [ "x$ntp_servers$" != "x" ] ; then
 cat << EOF >> /srv/salt/platform-salt/pillar/env_parameters.sls
 ntp:
   servers:
-    - "$ntp_servers$"
+    "$ntp_servers$"
 EOF
 fi
 


### PR DESCRIPTION
Understanding the Requirements:
PNDA-3299:  Add multiple NTP servers as list in the pnda_env.yaml file. 

Analysis
Right now the single NTP server from pnda_env.yaml is supported. The OS::Pnda::preConfig is not in pnda_env.yaml, no need any NTP servers, since the ntp.conf by default having public NTP servers and which is reachable. For REJECT_OUTBOUND : "YES", due to blocking of public internet through IPTABLES, NTP servers can't be reached.

Solution
OS::Pnda::preConfig - key in pnda_env.yaml: Pass NTP servers in pnda_env.yaml file. Getting these list allow in servers by configuring IPTABLES in PNDA instances.
OS::Pnda::preConfig - key in not pnda_env.yaml : No need any configuration, instances can reach default public NTP servers.

File modified
pnda_env_example : Adding NTP_SERVERS key entery for NTP list
scripts/package-install.sh : Adidng NTP servers in IPTABLES
scripts/saltmaster-common.sh : Modify the code to accept list of NTP servers.

Testcase
1. RHEL online PICO with multiple (3) internal NTP servers. Validated by shuting down one and then 2 NTP servers.
2. Ubuntu online PICO with multiple (3) internal NTP servers. Validated by shuting down one and then 2 NTP servers.
3. Ubuntu online Standard with multiple (3) internal and one public ntp.ubuntu.com NTP servers
