### PR TITLE
Adding Help command and Stack name validation #126

### DIFF
--- a/tools/check-stack.sh
+++ b/tools/check-stack.sh
@@ -1,7 +1,27 @@
+if [[ $1 == "" ]] || [[ $2 != "" ]]; then
+    echo "Try  'check-stack.sh --help '  for more information"
+    exit -1;
+fi
+
+if [[ $1 == "--help" ]] || [[ $1 == "-h" ]]; then
+    echo "Usage check-stack.sh <stack-name>"
+    echo "Example: check-stack.sh pnda"
+    exit -1;
+fi
+
 D=$(date)
 LOG="$1.stack.log"
 echo "$D" > $LOG
 IFS=$'\n'
+
+output=$(openstack stack resource list $1 2>&1)
+
+if [[ "$output" =~ "Stack not found" ]]; then
+    echo "*** Stack not found: $1"
+    echo "*** stack not found: $1" >> $LOG 2>&1
+    exit -1;
+fi
+
 stacks=$(openstack stack list --nested | grep $1)
 for stackline in $stacks; do echo $stackline >> $LOG 2>&1; done
 for stackline in $stacks


### PR DESCRIPTION

Add Help command and Stack name validation in check-stack.sh file.

Analysis
Right now Help command argument and Stack name validation is not handled.

Solution
Help command is added if user runs script with invalid arguments script will intimate regarding script usage with print messages
Stack name is handled if user runs script with invalid Stack name script will intimate with print messages

File modified
check-stack.sh : Adding Help command and Stack name validation

Testcase
1. Running script without any arguments.
2. Running script with more than one arguments.
3. Running script with help argument (--help).
4. Running script with help argument (-h).
5. Running script with valid stack name.
6. Running script with invalid stack name.