### PR TITLE
Fix #137 Hostname issue in mgr node

### DIFF
--- a/templates/bmstandard/pnda_cluster.yaml.j2
+++ b/templates/bmstandard/pnda_cluster.yaml.j2
@@ -276,7 +276,7 @@ resources:
       KeyName: { get_param: KeyName }
       name:
         str_replace:
-          template: '%stackname%-hadoop-mgr1'
+          template: '%stackname%-hadoop-mgr-1'
           params:
             '%stackname%': { get_param: deployment_name }
 {%if create_network is equalto 1 %}
@@ -296,7 +296,7 @@ resources:
       KeyName: { get_param: KeyName }
       name:
         str_replace:
-          template: '%stackname%-hadoop-mgr2'
+          template: '%stackname%-hadoop-mgr-2'
           params:
             '%stackname%': { get_param: deployment_name }
 {%if create_network is equalto 1 %}

--- a/templates/pico/pnda_cluster.yaml.j2
+++ b/templates/pico/pnda_cluster.yaml.j2
@@ -213,7 +213,7 @@ resources:
       Image: { get_param: image_id }
       name:
         str_replace:
-          template: '%stackname%-hadoop-mgr1'
+          template: '%stackname%-hadoop-mgr-1'
           params:
             '%stackname%': { get_param: deployment_name }
 {%if create_network is equalto 1 %}

--- a/templates/standard/pnda_cluster.yaml.j2
+++ b/templates/standard/pnda_cluster.yaml.j2
@@ -472,7 +472,7 @@ resources:
       KeyName: { get_param: KeyName }
       name:
         str_replace:
-          template: '%stackname%-hadoop-mgr1'
+          template: '%stackname%-hadoop-mgr-1'
           params:
             '%stackname%': { get_param: deployment_name }
       PrivateNet: { get_param: private_net }
@@ -496,7 +496,7 @@ resources:
       KeyName: { get_param: KeyName }
       name:
         str_replace:
-          template: '%stackname%-hadoop-mgr2'
+          template: '%stackname%-hadoop-mgr-2'
           params:
             '%stackname%': { get_param: deployment_name }
       PrivateNet: { get_param: private_net }
@@ -520,7 +520,7 @@ resources:
       KeyName: { get_param: KeyName }
       name:
         str_replace:
-          template: '%stackname%-hadoop-mgr3'
+          template: '%stackname%-hadoop-mgr-3'
           params:
             '%stackname%': { get_param: deployment_name }
       PrivateNet: { get_param: private_net }
@@ -543,7 +543,7 @@ resources:
       KeyName: { get_param: KeyName }
       name:
         str_replace:
-          template: '%stackname%-hadoop-mgr4'
+          template: '%stackname%-hadoop-mgr-4'
           params:
             '%stackname%': { get_param: deployment_name }
       PrivateNet: { get_param: private_net }


### PR DESCRIPTION
Problem Statement:
=================
Fix #137 : Hadoop installation failed as execution failed due to "java illegal argument hostname".

Analysis:
=========
 Mgr node template in pnda-heat-templates provide hostname in /etc/hosts as "%stackname%-hadoop-mgr1", whereas in platform-salt templates we see the hadoop name node as "%(cluster_name)s-hadoop-mgr-1". This causes hostname name resolution failure.

Solution:
========
Fix : Change the name node from "%stackname%-hadoop-mgr1" to "%stackname%-hadoop-mgr-1" in pnda flavor templates.

Tests:
=====
1. Deploy PNDA for PICO and STANDARD flavours for Ubuntu CDH & HDP.
2. Deploy PNDA for PICO and STANDARD flavours for Rhel CDH & HDP.