### PR TITLE
Mine for network ip address fixed

### DIFF
--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -7,6 +7,9 @@ parameter_defaults:
   public_net: 5982b761-802a-4af3-9c0b-c3b457559179
   
   #
+  mine_functions_network_ip_addrs_nic: eth0
+  # 
+  #
   # private_net_cidr: CIDR specifying the address range that the private network
   # should be created with
   #
@@ -194,6 +197,3 @@ resource_registry:
   #OS::Pnda::preConfig : iptracker.yaml
   # To enable the ip rejecting config script uncomment the next line.
   #OS::Pnda::preConfig : iprejecter.yaml
-
-mine_functions:
-  mine_functions_network_ip_addrs_nic: eth0


### PR DESCRIPTION
Fix #129 

Issue : 
Mine function in pnda_env_example is not working.

Solution : 
Remove the mine_functions section, add "mine_functions_network_ip_addrs_nic: eth0"  in default parameter_defaults section.