### PR TITLE
Fixes #143: Added pnda_internal_network and pnda_ingest_network as gr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Changed
 - PNDA-3583: hadoop distro is now part of grains
+- Issue-143: Added pnda_internal_network and pnda_ingest_network as grains.
 
 ## [1.4.0] 2017-11-24
 ### Added:

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -194,6 +194,9 @@ parameter_defaults:
   #
   #hypervisor_count: 30
 
+  pnda_internal_network: eth0
+  pnda_ingest_network: eth0
+
 resource_registry:
   #
   # OS::Pnda::preConfig: the resource definition of a pre configuration file

--- a/scripts/base_install.sh
+++ b/scripts/base_install.sh
@@ -74,6 +74,14 @@ roles: [${ROLES}]
 EOF
 fi
 
+if [ "$pnda_internal_network$" != "$" ] && [ "$pnda_ingest_network$" != "$" ]; then
+cat >> /etc/salt/grains <<EOF
+vlans:
+  pnda: $pnda_internal_network$
+  ingest: $pnda_ingest_network$
+EOF
+fi
+
 PIP_INDEX_URL="$pnda_mirror$/mirror_python/simple"
 TRUSTED_HOST=$(echo $PIP_INDEX_URL | awk -F'[/:]' '/http:\/\//{print $4}')
 cat << EOF > /etc/pip.conf

--- a/templates/bmstandard/kafka.yaml.j2
+++ b/templates/bmstandard/kafka.yaml.j2
@@ -55,6 +55,12 @@ parameters:
     default: ''
   package_config:
     type: string
+  pnda_internal_network:
+    type: string
+    default: ''
+  pnda_ingest_network:
+    type: string
+    default: ''
 
 resources:
 {%if create_network is equalto 1 %}
@@ -94,6 +100,8 @@ resources:
 {%endif%}
             $roles$: 'kafka,zookeeper'
             $$SPECIFIC_CONF$$: { get_param: specific_config }
+            $pnda_internal_network$: { get_param: pnda_internal_network }
+            $pnda_ingest_network$: { get_param: pnda_ingest_network }
   install_deployment:
     type: OS::Heat::SoftwareDeployment
 {%if create_volumes is equalto 1 %}

--- a/templates/bmstandard/scripts/kafka_install.sh
+++ b/templates/bmstandard/scripts/kafka_install.sh
@@ -79,6 +79,14 @@ roles: [${ROLES}]
 EOF
 fi
 
+if [ "$pnda_internal_network$" != "$" ] && [ "$pnda_ingest_network$" != "$" ]; then
+cat >> /etc/salt/grains <<EOF
+vlans:
+  pnda: $pnda_internal_network$
+  ingest: $pnda_ingest_network$
+EOF
+fi
+
 PIP_INDEX_URL="$pnda_mirror$/mirror_python/simple"
 TRUSTED_HOST=$(echo $PIP_INDEX_URL | awk -F'[/:]' '/http:\/\//{print $4}')
 cat << EOF > /etc/pip.conf

--- a/templates/distribution/kafka.yaml.j2
+++ b/templates/distribution/kafka.yaml.j2
@@ -56,6 +56,12 @@ parameters:
     default: ''
   package_config:
     type: string
+  pnda_internal_network:
+    type: string
+    default: ''
+  pnda_ingest_network:
+    type: string
+    default: ''
 
 resources:
 {%if create_network is equalto 1 %}
@@ -94,6 +100,8 @@ resources:
             $volume_dev$: { get_param: log_mountpoint }
             $roles$: 'kafka,zookeeper'
             $$SPECIFIC_CONF$$: { get_param: specific_config }
+            $pnda_internal_network$: { get_param: pnda_internal_network }
+            $pnda_ingest_network$: { get_param: pnda_ingest_network }
   install_deployment:
     type: OS::Heat::SoftwareDeployment
 {%if create_volumes is equalto 1 %}

--- a/templates/distribution/scripts/kafka_install.sh
+++ b/templates/distribution/scripts/kafka_install.sh
@@ -79,6 +79,14 @@ roles: [${ROLES}]
 EOF
 fi
 
+if [ "$pnda_internal_network$" != "$" ] && [ "$pnda_ingest_network$" != "$" ]; then
+cat >> /etc/salt/grains <<EOF
+vlans:
+  pnda: $pnda_internal_network$
+  ingest: $pnda_ingest_network$
+EOF
+fi
+
 PIP_INDEX_URL="$pnda_mirror$/mirror_python/simple"
 TRUSTED_HOST=$(echo $PIP_INDEX_URL | awk -F'[/:]' '/http:\/\//{print $4}')
 cat << EOF > /etc/pip.conf

--- a/templates/pico/kafka.yaml.j2
+++ b/templates/pico/kafka.yaml.j2
@@ -65,6 +65,12 @@ parameters:
     default: ''
   hadoop_distro:
     type: string
+  pnda_internal_network:
+    type: string
+    default: ''
+  pnda_ingest_network:
+    type: string
+    default: ''
 
 resources:
 {%if create_network is equalto 1 %}
@@ -95,6 +101,8 @@ resources:
             $roles$: 'kafka,kafka_manager,platform_testing_general,elk,zookeeper,kafka_tool'
             $$SPECIFIC_CONF$$: { get_param: specific_config }
             $hadoop_distro$: { get_param: hadoop_distro }
+	    $pnda_internal_network$: { get_param: pnda_internal_network }
+	    $pnda_ingest_network$: { get_param: pnda_ingest_network }
   deploy_package:
     type: OS::Heat::SoftwareDeployment
     properties:

--- a/templates/standard/kafka.yaml.j2
+++ b/templates/standard/kafka.yaml.j2
@@ -61,6 +61,12 @@ parameters:
     default: ''
   hadoop_distro:
     type: string
+  pnda_internal_network:
+    type: string
+    default: ''
+  pnda_ingest_network:
+    type: string
+    default: '
 
 resources:
   port:
@@ -87,6 +93,8 @@ resources:
             $roles$: 'kafka,kafka_tool'
             $$SPECIFIC_CONF$$: { get_param: specific_config }
             $hadoop_distro$: { get_param: hadoop_distro }
+            $pnda_internal_network$: { get_param: pnda_internal_network }
+            $pnda_ingest_network$: { get_param: pnda_ingest_network }
   deploy_package:
     type: OS::Heat::SoftwareDeployment
     properties:


### PR DESCRIPTION
Issue description:
In "PNDA-3573",  default values for "internal_ip" and "ingest_ip"
are removed . These values must be provided in pnda environment file.

Tested for following in OpenStack:
CDH - RHEL for pico and standard flavors
HDP - RHEL for pico and standard flavors

**Note: This fix was tested along with fixes for issues 144 , 145 and 146.** 