### PR TITLE
Fixes #144: Added param "hadoop_distro" to mgr1 node template for pico flavor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - PNDA-3583: hadoop distro is now part of grains
 - Issue-143: Added pnda_internal_network and pnda_ingest_network as grains.
+- Issue-144: Added param "hadoop_distro" to mgr1 node template for pico flavor.
 
 ## [1.4.0] 2017-11-24
 ### Added:

--- a/templates/pico/mgr1.yaml.j2
+++ b/templates/pico/mgr1.yaml.j2
@@ -58,6 +58,8 @@ parameters:
     default: ''
   package_config:
     type: string
+  hadoop_distro:
+    type: string
 
 resources:
 {%if create_network is equalto 1 %}
@@ -101,6 +103,7 @@ resources:
             $roles$: 'mysql_connector,oozie_database,hue,opentsdb,grafana'
             $hadoop_role$: 'MGR01'
             $$SPECIFIC_CONF$$: { get_param: specific_config }
+            $hadoop_distro$: { get_param: hadoop_distro }	    
   deploy_package:
     type: OS::Heat::SoftwareDeployment
     properties:


### PR DESCRIPTION
Issue description:
-------------------
Heat template of  "mgr1 node" in pico flavor calls the bootstrap script "base_install.sh".
The script expects parameter "hadoop_distro" to set the value of the grain.
This parameter is not passed to this script in the mgr1.yaml.j2 file.

Tested for following in OpenStack:
CDH - RHEL for pico and standard flavors
HDP - RHEL for pico and standard flavors

**Note: This fix was tested along with fixes for issues 143 , 145 and 146.**