### PR TITLE
Fixes #145: Added "hadoop.distro" grain to saltmaster_install bootstrap script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3583: hadoop distro is now part of grains
 - Issue-143: Added pnda_internal_network and pnda_ingest_network as grains.
 - Issue-144: Added param "hadoop_distro" to mgr1 node template for pico flavor.
+- Issue-145: Added "hadoop.distro" grain to saltmaster_install bootstrap script.
 
 ## [1.4.0] 2017-11-24
 ### Added:

--- a/scripts/saltmaster_install.sh
+++ b/scripts/saltmaster_install.sh
@@ -205,6 +205,7 @@ pnda:
   flavor: $flavor$
   is_new_node: True
 pnda_cluster: $pnda_cluster$
+hadoop.distro: '$hadoop_distro$'
 EOF
 
 

--- a/templates/pnda.yaml
+++ b/templates/pnda.yaml
@@ -108,6 +108,8 @@ parameters:
     type: string
   pnda_archive_container:
     type: string
+  hadoop_distro:
+    type: string
   DeploymentID:
     type: string
     default: ''
@@ -296,6 +298,7 @@ resources:
             $pnda_apps_container$: { get_param: pnda_apps_container }
             $pnda_apps_folder$: { get_param: pnda_apps_folder }
             $pnda_archive_container$: { get_param: pnda_archive_container }
+            $hadoop_distro$: { get_param: hadoop_distro }
             $$SPECIFIC_CONF$$: { get_param: specific_config }
             $mine_functions_network_ip_addrs_nic$: { get_param: mine_functions_network_ip_addrs_nic}
 


### PR DESCRIPTION
Issue description:
------------------
Pillar fails to render with following message:
"Specified SLS 'hadoop.$' in environment 'base' is not available on the salt master"

Analysis
---------
In AWS environment edge node also takes role of salt-master, "hadoop.distro" grain is added from bootstrap-script "base.sh".
Whereas in OpenStack environment, a dedicated node serves as salt-master server. While rendering pillars, it expects "hadoop.distro" grain.

Solution
---------
This grain "hadoop.distro" should be added on saltmaster_install bootstrap-script.

Tested for following in OpenStack:
CDH - RHEL for pico and standard flavors
HDP - RHEL for pico and standard flavors

**Note: This fix was tested along with fixes for issues 143 , 144 and 146.**