### PR TITLE
Fixes #146: Updated new path of "hdp_core_stack_repo" in saltmaster_install bootstrap script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Issue-143: Added pnda_internal_network and pnda_ingest_network as grains.
 - Issue-144: Added param "hadoop_distro" to mgr1 node template for pico flavor.
 - Issue-145: Added "hadoop.distro" grain to saltmaster_install bootstrap script.
+- Issue-146: Updated new path of "hdp_core_stack_repo" in saltmaster_install bootstarp script.
 
 ## [1.4.0] 2017-11-24
 ### Added:

--- a/scripts/saltmaster_install.sh
+++ b/scripts/saltmaster_install.sh
@@ -137,7 +137,7 @@ pip:
   index_url: '$pnda_mirror$/mirror_python/simple'
 
 hdp:
-  hdp_core_stack_repo: '$pnda_mirror$/mirror_hdp/HDP/$HDP_OS/'
+  hdp_core_stack_repo: '$pnda_mirror$/mirror_hdp/HDP/$HDP_OS/2.6.3.0-235/'
   hdp_utils_stack_repo: '$pnda_mirror$/mirror_hdp/HDP-UTILS-1.1.0.21/repos/$HDP_OS/'
 mine_functions:
   network.ip_addrs: [$MINE_FUNCTIONS_NETWORK_INTERFACE]


### PR DESCRIPTION
Tested for following in OpenStack:
CDH - RHEL for pico and standard flavors
HDP - RHEL for pico and standard flavors

**Note: This fix was tested along with fixes for issues 143 , 144 and 145.**