### PR TITLE
Fixes #152: Cleanup of unicode characters erroneously present due to the previous commit.

### DIFF
--- a/templates/pico/kafka.yaml.j2
+++ b/templates/pico/kafka.yaml.j2
@@ -101,8 +101,8 @@ resources:
             $roles$: 'kafka,kafka_manager,platform_testing_general,elk,zookeeper,kafka_tool'
             $$SPECIFIC_CONF$$: { get_param: specific_config }
             $hadoop_distro$: { get_param: hadoop_distro }
-	    $pnda_internal_network$: { get_param: pnda_internal_network }
-	    $pnda_ingest_network$: { get_param: pnda_ingest_network }
+            $pnda_internal_network$: { get_param: pnda_internal_network }
+            $pnda_ingest_network$: { get_param: pnda_ingest_network }
   deploy_package:
     type: OS::Heat::SoftwareDeployment
     properties:

--- a/templates/pico/mgr1.yaml.j2
+++ b/templates/pico/mgr1.yaml.j2
@@ -103,7 +103,7 @@ resources:
             $roles$: 'mysql_connector,oozie_database,hue,opentsdb,grafana'
             $hadoop_role$: 'MGR01'
             $$SPECIFIC_CONF$$: { get_param: specific_config }
-            $hadoop_distro$: { get_param: hadoop_distro }	    
+            $hadoop_distro$: { get_param: hadoop_distro }
   deploy_package:
     type: OS::Heat::SoftwareDeployment
     properties:

--- a/templates/standard/kafka.yaml.j2
+++ b/templates/standard/kafka.yaml.j2
@@ -66,7 +66,7 @@ parameters:
     default: ''
   pnda_ingest_network:
     type: string
-    default: '
+    default: ''
 
 resources:
   port:


### PR DESCRIPTION
Tested  for :
1. CDH- Pico and Standard online for RHEL
2. HDP- Pico and Standard online for RHEL