### PR TITLE
PNDA-4214: Location of app packages on mirror

### DIFF
--- a/scripts/saltmaster_install.sh
+++ b/scripts/saltmaster_install.sh
@@ -122,6 +122,7 @@ cat << EOF >> /srv/salt/platform-salt/pillar/env_parameters.sls
 pnda_mirror:
   base_url: '$pnda_mirror$'
   misc_packages_path: /mirror_misc/
+  app_packages_path: /mirror_apps/
 
 hadoop:
   parcel_repo: '$pnda_mirror$/mirror_cloudera'


### PR DESCRIPTION
Added "pnda_mirror:  app_packages_path" pillar  in salt master bootstrap script.

Validations:
1. Pico - Ubuntu and RHEL
2. Standard - Ubuntu and RHEL